### PR TITLE
Add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+## Sumologic searchrunner tool
+
+> As of October 2020 this repo is no longer actively maintained by the GOV.UK Pay team, following the switch from
+> Sumologic to Splunk in March 2019.


### PR DESCRIPTION
Pay now uses Splunk instead of Sumologic.

Once this PR is merged we can archive this repo.